### PR TITLE
Documentation | Data Warehouse: Page parameter documentation, types

### DIFF
--- a/docs/reporting-api/data_types/r_report.md
+++ b/docs/reporting-api/data_types/r_report.md
@@ -13,6 +13,8 @@ A structure data type that returns data associated with a particular report requ
 | ` data ` | [reportDataList](r_reportDataList.md#) - an array of [reportData](r_reportData.md#) | The data that makes up the bulk of the report. |
 | ` totals ` | `array(double\) ` | A list of metric totals. |
 | ` version ` | ` xsd:string ` |   |
+| ` totalPages ` | `xsd:int` | Number of available pages for [Data Warehouse](../data_warehouse.md) requests. |
+| ` page ` | `xsd:int` | Current returned page (of `totalPages`) for [Data Warehouse](../data_warehouse.md) requests. |
 
 **Parent topic:** [Data Types](../data_types/datatypes.md)
 

--- a/docs/reporting-api/data_warehouse.md
+++ b/docs/reporting-api/data_warehouse.md
@@ -2,4 +2,6 @@
 
 Data Warehouse data is available through the Reporting API.
 
-You can run Data Warehouse reports in the Reporting API by setting `"source":"warehouse"` In the [Report.Queue](methods/r_Queue.md#) method.
+You can run Data Warehouse reports in the Reporting API by setting `"source":"warehouse"` In the [Report.Queue](methods/r_Queue.md#) method. This method returns a `reportID`;
+
+When using [Report.Get](methods/r_Get.md#), the returned [Report](data_types/r_report.md) may include multiple pages. To get data beyond the first page, make additional requests to [Report.Get](methods/r_Get.md#) and specify the `page` number in either the body or query string.

--- a/docs/reporting-api/methods/r_Get.md
+++ b/docs/reporting-api/methods/r_Get.md
@@ -9,6 +9,7 @@ Retrieves a report queued using Report.Queue
 |Name|Type|Description|
 |----|----|-----------|
 | ` reportID ` | `xsd:int` | Report ID returned by [Report.Queue](r_Queue.md#). |
+| ` page ` | `xsd:int` | (Optional) Desired page number (out of `totalPages`) for larger [Data Warehouse](../data_warehouse.md#) requests. |
 
 ## Report.Get response
 


### PR DESCRIPTION
## Description
The `Report.Get` method can accept a `page` parameter for multi-page reports. This was previously undocumented.


## Related Issue

This fixes issue #36 

## Motivation and Context

Fixing an issue that I reported

## How Has This Been Tested?

Using a TypeScript library ran in Node, I ensured changing the `page` parameter returned the desired data when using `Request.Get`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Documentation Fix

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
