### PR TITLE
Removing the try it out functionality from swagger

### DIFF
--- a/docs/swagger-docs.html
+++ b/docs/swagger-docs.html
@@ -3,14 +3,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- Google Tag Manager -->
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-WFH2HTG');</script>
-  <!-- End Google Tag Manager -->  
-
   <meta charset="UTF-8">
   <title>Swagger UI</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
@@ -39,10 +31,6 @@
 </head>
 
 <body>
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WFH2HTG"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0">
   <defs>
@@ -84,6 +72,25 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script src="./swagger-ui-standalone-preset.js"> </script>
 <script>
 window.onload = function() {
+
+	const DisableTryItOutPlugin = function() {
+		return {
+			statePlugins: {
+				spec: {
+					wrapSelectors: {
+						allowTryItOutFor: () => () => false
+					}
+				}
+			}
+		}
+	}
+	const DisableAuthorizePlugin = function() {
+		return {
+			wrapComponents: {
+				authorizeBtn: () => () => null
+			}
+		};
+	};
   
   // Build a system
   const ui = SwaggerUIBundle({
@@ -95,7 +102,9 @@ window.onload = function() {
       SwaggerUIStandalonePreset
     ],
     plugins: [
-      SwaggerUIBundle.plugins.DownloadUrl
+			SwaggerUIBundle.plugins.DownloadUrl,
+			DisableTryItOutPlugin,
+			DisableAuthorizePlugin
     ],
     layout: "StandaloneLayout"
   })


### PR DESCRIPTION
The authorization and try it out functionality in the 1.4 Swagger doesn't work.
These features do work in the 2.0 APIs and having the buttons available in 1.4 can be confusing.
I'm removing this functionality to make the UI more straight forward

## Description

I've added two swagger plugins to remove this functionality
I have also removed some unnecessary stats tagging 

## How Has This Been Tested?

I rendered the swagger UI locally on my machine and made sure that it loaded correctly and functioned without the try it out and authorize buttons. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
