### PR TITLE
AN-200429 Add --location-trusted info to Livestream docs

### DIFF
--- a/docs/live-stream-api/getting_started.md
+++ b/docs/live-stream-api/getting_started.md
@@ -24,16 +24,16 @@ Customer Care will need the following information to provision the stream:
 
 ## Connect to the Stream
 A connection request will look something like the following:
-```curl --location --compressed -H "Authorization: Bearer [JWT_TOKEN]" "[STREAM_URL]"```
+```curl --location-trusted --compressed -H "Authorization: Bearer [JWT_TOKEN]" "[STREAM_URL]"```
 
-* `--location` tells CURL to follow redirect requests.
+* `--location-trusted` tells CURL to follow redirects and send the authorization header again when a redirect happens
 * `--compressed` tells CURL to send the request header `Accept-Encoding: deflate, gzip`. Livestream only supports compressed responses in order to reduce bandwidth and avoid overwhelming clients.
 * `-H "Authorization: Bearer [JWT_TOKEN]` is where the JWT token [that was generated](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/AuthenticationOverview/ServiceAccountIntegration.md#step-4-try-it) using your service account should go. This authenticates the client with Livestream.
 
 > NOTE: The Adobe.io JWT tool isn't required to generate a JWT token. This can be done from within the client. [Example code can be found here for multiple platforms](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/JWT/samples/samples.md).
 
 Here is an example of a request (with the JWT token removed):
-```curl --location --compressed -H "Authorization: Bearer eyJ4NXUiO...e1OvbElA" https://livestream.adobe.net/api/1/stream/adobe-livestream-endpoint-name```
+```curl --location-trusted --compressed -H "Authorization: Bearer eyJ4NXUiO...e1OvbElA" https://livestream.adobe.net/api/1/stream/adobe-livestream-endpoint-name```
 
 Once connected to the stream, impression data will be streamed in a line-delimited JSON format and reflects data currently being collected by a report suite. For an example of a record returned in from Livestream, see the 'Livestream Sample JSON output' section of the [Metrics and Dimensions](https://github.com/AdobeDocs/analytics-1.4-apis/blob/master/docs/live-stream-api/metrics_dimensions.md) page.
 

--- a/docs/live-stream-api/troubleshooting.md
+++ b/docs/live-stream-api/troubleshooting.md
@@ -56,10 +56,10 @@ Clients that do a lot of aggregation, statistical modeling, etc, may struggle to
 It is possible to have multiple clients connect to the same stream. This is done using the `?maxConnections=[1-8]` GET string parameter.
 
 For example - the connection endpoint for client #1 would be:
-```curl --location --compressed -H "Authorization: Bearer eyJ4NXUiO...e1OvbElA" https://livestream.adobe.net/api/1/stream/adobe-livestream-endpoint-name?maxConnections=2```
+```curl --location-trusted --compressed -H "Authorization: Bearer eyJ4NXUiO...e1OvbElA" https://livestream.adobe.net/api/1/stream/adobe-livestream-endpoint-name?maxConnections=2```
 
 The endpoint for client #2 would be the same:
-```curl --location --compressed -H "Authorization: Bearer eyJ4NXUiO...e1OvbElA" https://livestream.adobe.net/api/1/stream/adobe-livestream-endpoint-name?maxConnections=2```
+```curl --location-trusted --compressed -H "Authorization: Bearer eyJ4NXUiO...e1OvbElA" https://livestream.adobe.net/api/1/stream/adobe-livestream-endpoint-name?maxConnections=2```
 
 The maximum number of clients is 8.
 


### PR DESCRIPTION
## Description
We need to use `--location-trusted` in curl requests so that the authorization header is sent to the redirected host. The docs need to reflect that.

## Motivation and Context
This PR fixes the documented Livestream examples.

## How Has This Been Tested?
I tested this by sending a curl request with the `--location-trusted` to a test host to make sure that it both follows the redirect in the response and sends the auth header to the redirected host.

## Checklist:
- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
