### PR TITLE
rsid_list is not optional

### DIFF
--- a/docs/classifications-api/methods/r_CreateImport.md
+++ b/docs/classifications-api/methods/r_CreateImport.md
@@ -12,7 +12,7 @@ After sending all data, call [CommitImport](r_CommitImport.md#) to finalize the 
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-| **rsid\_list** | `array(xsd:string)` | \(Optional\) The list of report suites to receive the import job. |
+| **rsid\_list** | `array(xsd:string)` | The list of report suites to receive the import job. |
 | **element** | `xsd:string` |The report for which you want to perform a classifications import.|
 | **check\_divisions** | `xsd:int` | Specifies whether to check report suites for compatible divisions. Supported values include: `0`: Do not check report suite compatibility. `1`: \(Default\) Check report suite compatibility. |
 | **description** | `xsd:string` | A description of the import job. |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 RSID List is not optional. 

API Response tells -

```
{
    "error": "Bad Request",
    "error_description": "rsid_list is a required array of report suites.",
    "error_uri": null
}
```

If you skip that option.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Betterment of Docs
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5828500/90121840-1d90d100-dd7a-11ea-9d06-20507b0e5c04.png)

## Types of changes
Documentation
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
