### PR TITLE
Soften 1.4 EOL parity language

### DIFF
--- a/src/pages/guides/eol.md
+++ b/src/pages/guides/eol.md
@@ -11,9 +11,9 @@ Adobe plans to retire the Adobe Analytics 1.4 API on **August 12, 2026**. All en
 
 ## 1.4 APIs
 
-The Adobe Analytics 1.4 APIs provide a wide range of actions, such as reporting, classifications, data feeds, and report suite configurations. They are being sunset in favor of the [Adobe Analytics 2.0 APIs](https://developer.adobe.com/analytics-apis/docs/2.0/). The 2.0 APIs allow you to perform almost any action that you can perform in the Analytics user interface, such such as reporting or managing components like segments and calculated metrics.
+The Adobe Analytics 1.4 APIs provide a wide range of actions, such as reporting, classifications, data feeds, and report suite configurations. They are being sunset in favor of the [Adobe Analytics 2.0 APIs](https://developer.adobe.com/analytics-apis/docs/2.0/). The 2.0 APIs allow you to perform almost any action that you can perform in the Analytics user interface, such as reporting or managing components like segments and calculated metrics.
 
-Adobe offers a [migration path](https://developer.adobe.com/analytics-apis/docs/2.0/guides/migration/) for 1.4 API users. You can migrate your integrations to the 2.0 APIs (the same APIs that the Adobe Analytics application depends on) and take advantage of the latest features. Any capabilities that are available in the 1.4 APIs can be accomplished using the [Adobe Analytics 2.0 APIs](https://developer.adobe.com/analytics-apis/docs/2.0/).
+Adobe offers a [migration path](https://developer.adobe.com/analytics-apis/docs/2.0/guides/migration/) for 1.4 API users. You can migrate your integrations to the 2.0 APIs (the same APIs that the Adobe Analytics application depends on) and take advantage of the latest features. The 2.0 APIs support a broad range of 1.4 use cases, including reporting, segmentation, and component management. Adobe is actively expanding 2.0 API coverage to address additional migration scenarios. Refer to the [migration guide](https://developer.adobe.com/analytics-apis/docs/2.0/guides/migration/) for the latest guidance on specific workflows, or contact your Adobe Account Team with questions.
 
 ## WSSE Authentication
 


### PR DESCRIPTION
## Summary

- Removes the inaccurate blanket claim that _all_ 1.4 API capabilities can be accomplished using the 2.0 APIs
- Replaces with accurate language describing broad 2.0 coverage while noting Adobe is actively expanding coverage for additional migration scenarios
- Fixes a duplicate-word typo ("such such as")

## Why

The existing language stating "Any capabilities that are available in the 1.4 APIs can be accomplished using the Adobe Analytics 2.0 APIs" is not accurate for all use cases (notably certain report suite administration workflows). This overclaim has caused customer confusion and escalations. The updated language is honest without being alarmist, and avoids committing to specific delivery timelines.